### PR TITLE
Fix React error #130 on desktop (word cloud not rendering)

### DIFF
--- a/src/components/InterestCloud.tsx
+++ b/src/components/InterestCloud.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import { Hobbies } from "../types";
-import Wordcloud from '@visx/wordcloud/lib/Wordcloud';
+import Wordcloud from '@visx/wordcloud/esm/Wordcloud';
 import { Text } from '@visx/text';
 import { scaleLog } from '@visx/scale';
 


### PR DESCRIPTION
## Summary

- Fixes `React error #130` ("Element type is invalid: expected string or function but got: object") that broke the site on laptop/desktop
- The word cloud in the Interests section was rendering fine on mobile (hidden behind a viewport-width gate) but crashing on desktop

## Root Cause

Vite 8 switched its bundler from Rollup to Rolldown. Rolldown has a CJS interop bug: when a CJS module declares `exports.__esModule = true` **and** is imported via a direct file path (bypassing the package `exports`/`module` fields), Rolldown wraps the entire `module.exports` object as the default export instead of using `exports.default`.

`@visx/wordcloud/lib/Wordcloud` is exactly such a module. At runtime, `Wordcloud` resolved to `{ __esModule: true, default: <fn> }` (a plain object) rather than the component function — React then threw error #130 when trying to render it.

## Fix

One-line change in `InterestCloud.tsx`: switch the import from the CJS `/lib/` path to the ESM `/esm/` path.

```diff
-import Wordcloud from '@visx/wordcloud/lib/Wordcloud';
+import Wordcloud from '@visx/wordcloud/esm/Wordcloud';
```

Rolldown inlines the ESM function directly with no interop wrapping, so `Wordcloud` is correctly the component function.

---
_Generated by [Claude Code](https://claude.ai/code/session_016jtYoALVPx47HLTrWBR2sU)_